### PR TITLE
Look into the package.xml files to find subfolders

### DIFF
--- a/aurci/update.py
+++ b/aurci/update.py
@@ -4,7 +4,7 @@ import sys
 import re
 import subprocess
 import urllib
-
+import xml.etree.ElementTree as ET
 
 class Update(Routines):
 
@@ -100,8 +100,11 @@ class Update(Routines):
         repo = self.gh.get_repo(repo_name)
         contents = repo.get_contents(".")
         for content in contents:
-            if self.package_info['orig_name'] in content.path and content.type == 'dir':
-                return content.path
+            if content.name == 'package.xml':
+                root = ET.fromstring(content.decoded_content)
+                name = root.find('name')
+                if name.text == self.package_info['orig_name']:
+                    return os.path.dirname(content.path)
             if content.type == 'dir':
                 contents.extend(repo.get_contents(content.path))
         raise RuntimeError("Can't find nested path: " + self.package)


### PR DESCRIPTION
In fact, the subfolder does not have to contain the package name at all.
Assuming this created a couple of false positives (e.g. rosbag_storage -> test/test_rosbag_storage)

If we look into the package.xml files the name has to exactly match the package name.

This would make #3 oboslete and solves #1 

I don't really like the drawback that this only works with Github repositories, but that was the same before.